### PR TITLE
feat: 노트 나갈 경우 요청을 받아 열람 시간을 확인할 수 있다

### DIFF
--- a/src/main/java/com/dot/osore/core/note/controller/NoteController.java
+++ b/src/main/java/com/dot/osore/core/note/controller/NoteController.java
@@ -78,4 +78,14 @@ public class NoteController {
             return Response.failure(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION);
         }
     }
+
+    @PostMapping("/{noteId}/exit")
+    public Response exitNote(@PathVariable Long noteId, @Login SignInInfo signInInfo) {
+        try {
+            noteService.changeViewedAt(noteId);
+            return Response.success();
+        } catch (Exception e) {
+            return Response.failure(ErrorCode.MEMBER_NOT_FOUND_EXCEPTION);
+        }
+    }
 }

--- a/src/main/java/com/dot/osore/core/note/dto/DetailNoteResponse.java
+++ b/src/main/java/com/dot/osore/core/note/dto/DetailNoteResponse.java
@@ -12,7 +12,8 @@ public record DetailNoteResponse(
         String description,
         Integer contributorsCount,
         Integer starsCount,
-        Integer forksCount
+        Integer forksCount,
+        ViewedDateTime viewedAt
 ) {
 
     public static DetailNoteResponse from(Note note) {
@@ -25,7 +26,8 @@ public record DetailNoteResponse(
                     note.getDescription(),
                     note.getContributorsCount(),
                     note.getStarsCount(),
-                    note.getForksCount()
+                    note.getForksCount(),
+                    ViewedDateTime.from(note.getViewedAt())
             );
         } catch (Exception e) {
             throw new IllegalArgumentException("잘못된 URL 형식입니다.");

--- a/src/main/java/com/dot/osore/core/note/dto/ViewedDateTime.java
+++ b/src/main/java/com/dot/osore/core/note/dto/ViewedDateTime.java
@@ -1,0 +1,42 @@
+package com.dot.osore.core.note.dto;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+public record ViewedDateTime(
+        Long number,
+        String unit
+) {
+
+    public static ViewedDateTime from(LocalDateTime viewedAt) {
+        LocalDateTime now = LocalDateTime.now();
+
+        long diff = ChronoUnit.SECONDS.between(viewedAt, now);
+        if (diff < 60) {
+            return new ViewedDateTime(diff, "seconds");
+        }
+
+        diff = ChronoUnit.MINUTES.between(viewedAt, now);
+        if (diff < 60) {
+            return new ViewedDateTime(diff, "minutes");
+        }
+
+        diff = ChronoUnit.HOURS.between(viewedAt, now);
+        if (diff < 24) {
+            return new ViewedDateTime(diff, "hours");
+        }
+
+        diff = ChronoUnit.DAYS.between(viewedAt, now);
+        if (diff < 30) {
+            return new ViewedDateTime(diff, "days");
+        }
+
+        diff = ChronoUnit.MONTHS.between(viewedAt, now);
+        if (diff < 12) {
+            return new ViewedDateTime(diff, "months");
+        }
+
+        diff = ChronoUnit.YEARS.between(viewedAt, now);
+        return new ViewedDateTime(diff, "years");
+    }
+}

--- a/src/main/java/com/dot/osore/core/note/entity/Note.java
+++ b/src/main/java/com/dot/osore/core/note/entity/Note.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,13 +52,17 @@ public class Note extends BaseEntity {
     @Column(name = "version")
     private String version;
 
+    @Column(name = "viewedAt")
+    private LocalDateTime viewedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @Builder
     public Note(String url, String title, String avatar, String description, Integer contributorsCount,
-                Integer starsCount, Integer forksCount, String branch, String version, Member member) {
+                Integer starsCount, Integer forksCount, String branch, String version, Member member,
+                LocalDateTime viewedAt) {
         this.url = url;
         this.title = title;
         this.avatar = avatar;
@@ -68,9 +73,14 @@ public class Note extends BaseEntity {
         this.branch = branch;
         this.version = version;
         this.member = member;
+        this.viewedAt = viewedAt;
     }
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public void setViewedAt(LocalDateTime viewedAt) {
+        this.viewedAt = viewedAt;
     }
 }

--- a/src/main/java/com/dot/osore/core/note/repository/NoteRepository.java
+++ b/src/main/java/com/dot/osore/core/note/repository/NoteRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NoteRepository extends JpaRepository<Note, Long> {
-    List<Note> findByMember_Id(Long id);
+    List<Note> findBymember_IdOrderByViewedAtDesc(Long signInId);
 }

--- a/src/main/java/com/dot/osore/core/note/service/NoteService.java
+++ b/src/main/java/com/dot/osore/core/note/service/NoteService.java
@@ -12,6 +12,7 @@ import com.dot.osore.core.note.entity.Note;
 import com.dot.osore.core.note.repository.NoteRepository;
 import com.dot.osore.global.github.GithubConnector;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class NoteService {
      * @param signInId 사용자 Id
      */
     public List<DetailNoteResponse> getNoteList(Long signInId) {
-        List<Note> notes = noteRepository.findByMember_Id(signInId);
+        List<Note> notes = noteRepository.findBymember_IdOrderByViewedAtDesc(signInId);
         List<DetailNoteResponse> notesResponse = new ArrayList<>();
         notes.forEach(note ->
                 notesResponse.add(DetailNoteResponse.from(note)));
@@ -92,6 +93,7 @@ public class NoteService {
                 .branch(note.branch())
                 .version(note.version())
                 .member(member)
+                .viewedAt(LocalDateTime.now())
                 .build());
         fileService.saveRepositoryFiles(note.url(), note.branch(), savedNote);
     }
@@ -118,5 +120,17 @@ public class NoteService {
         Note note = noteRepository.findById(noteId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 노트를 찾을 수 없습니다."));
         note.setTitle(title);
+    }
+
+    /**
+     * 노트의 열람 시간을 변경하는 메서드
+     *
+     * @param noteId 노트 Id
+     */
+    @Transactional
+    public void changeViewedAt(Long noteId) {
+        Note note = noteRepository.findById(noteId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 노트를 찾을 수 없습니다."));
+        note.setViewedAt(LocalDateTime.now());
     }
 }

--- a/src/test/java/com/dot/osore/core/note/service/NoteServiceTest.java
+++ b/src/test/java/com/dot/osore/core/note/service/NoteServiceTest.java
@@ -7,6 +7,7 @@ import com.dot.osore.core.member.entity.Member;
 import com.dot.osore.core.note.dto.NoteRequest;
 import com.dot.osore.core.note.dto.DetailNoteResponse;
 import com.dot.osore.core.note.entity.Note;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ class NoteServiceTest extends TestContext {
                     .branch("test1")
                     .version("test1")
                     .member(savedMember)
+                    .viewedAt(LocalDateTime.now())
                     .build();
 
             Note testNote2 = Note.builder()
@@ -49,6 +51,7 @@ class NoteServiceTest extends TestContext {
                     .branch("test2")
                     .version("test2")
                     .member(savedMember)
+                    .viewedAt(LocalDateTime.now())
                     .build();
             noteRepository.save(testNote1);
             noteRepository.save(testNote2);


### PR DESCRIPTION
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description

- Note 엔티티에 열람 시간을 추가합니다
- 요청을 받으면 해당 열람 시간 컬럼을 업데이트 합니다
- 노트 리스트 반환 시 열람 시간을 함께 반환합니다
- 노트 리스트 반환 시 열람 시간에 맞게 정렬한다

<!-- If applicable, add screenshots to help explain your changes -->

## Demo
