### PR TITLE
fix: 노트 삭제 시 내부의 채팅방이 삭제된다

### DIFF
--- a/src/main/java/com/dot/osore/core/chat/repository/ChatRepository.java
+++ b/src/main/java/com/dot/osore/core/chat/repository/ChatRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+    void deleteByChattingRoomId(Long id);
 }

--- a/src/main/java/com/dot/osore/core/chat/repository/ChattingRoomRepository.java
+++ b/src/main/java/com/dot/osore/core/chat/repository/ChattingRoomRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long> {
     List<ChattingRoom> findByNoteIdOrderByCreatedAtDesc(Long noteId);
+
+    void deleteByNoteId(Long noteId);
 }

--- a/src/main/java/com/dot/osore/core/chat/service/ChatService.java
+++ b/src/main/java/com/dot/osore/core/chat/service/ChatService.java
@@ -151,4 +151,16 @@ public class ChatService {
             return null;
         }
     }
+
+    /**
+     * 채팅방을 삭제하는 메서드
+     *
+     * @param noteId 노트 아이디
+     */
+    @Transactional
+    public void deleteChatRoomByNoteId(Long noteId) {
+        List<ChattingRoom> chattingRooms = chattingRoomRepository.findByNoteIdOrderByCreatedAtDesc(noteId);
+        chattingRooms.forEach(chattingRoom -> chatRepository.deleteByChattingRoomId(chattingRoom.getId()));
+        chattingRoomRepository.deleteByNoteId(noteId);
+    }
 }

--- a/src/main/java/com/dot/osore/core/note/controller/NoteController.java
+++ b/src/main/java/com/dot/osore/core/note/controller/NoteController.java
@@ -73,6 +73,7 @@ public class NoteController {
     @DeleteMapping("/{noteId}")
     public Response deleteNote(@PathVariable Long noteId, @Login SignInInfo signInInfo) {
         try {
+            chatService.deleteChatRoomByNoteId(noteId);
             noteService.deleteNote(noteId);
             DetailNoteListResponse response = new DetailNoteListResponse(noteService.getNoteList(signInInfo.id()));
             return Response.success(response);


### PR DESCRIPTION
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context -->

## Description
- 노트 삭제 시 채팅방을 모두 삭제합니다
<!-- If applicable, add screenshots to help explain your changes -->

## Demo
